### PR TITLE
Refactor Controller/Service/Dao APIs to support more proxying capabilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,12 +9,12 @@ This is an important component with a couple of use cases.
  * Picture this module deployed as a façade for ESB endpoints. `my.wisc.edu/esb/someservice/api/foo` . You could theoretically write 100% javascript apps against the proxy proxying ESB-provided JSON.
 
 ### Add Proxy Servlet to Existing Service
-+ Configure your `Spring application context` to collect annotation beans from edu.wisc.my.util
++ A Spring `@Configuration` class is provided, simply `@Import(edu.wisc.my.restproxy.config.RestProxyConfiguration)` on one of your existing `@Configuration` classes. If you are using Spring's XML configuration instead, add the following to your `Spring application context`:
 ```xml
     <mvc:annotation-driven/>
     <context:component-scan base-package="edu.wisc.my.restproxy"/>
 ```
-+ Setup a servlet 
++ Setup a servlet:
 ```xml
     <servlet>
         <servlet-name>json-proxy-api</servlet-name>

--- a/pom.xml
+++ b/pom.xml
@@ -65,6 +65,11 @@
       <artifactId>jackson-databind</artifactId>
       <version>2.2.0</version>
     </dependency>
+    <dependency>
+  		<groupId>com.google.guava</groupId>
+  		<artifactId>guava</artifactId>
+  		<version>18.0</version>
+	</dependency>
     
     <!-- Spring compile -->
     <dependency>
@@ -119,19 +124,31 @@
     <!-- provided -->
     
     <dependency>
-      <groupId>javax.servlet</groupId>
-      <artifactId>servlet-api</artifactId>
-      <scope>provided</scope>
-      <version>2.5</version>
-    </dependency>
+    <groupId>javax.servlet</groupId>
+    <artifactId>javax.servlet-api</artifactId>
+    <version>3.0.1</version>
+    <scope>provided</scope>
+	</dependency>
     
     <!-- test -->
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>3.8.1</version>
+      <version>4.11</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+    	<groupId>org.mockito</groupId>
+    	<artifactId>mockito-core</artifactId>
+    	<version>1.9.5</version>
+    	<scope>test</scope>
+    </dependency>
+	<dependency>
+		<groupId>org.springframework</groupId>
+		<artifactId>spring-test</artifactId>
+		<version>${spring.version}</version>
+		<scope>test</scope>
+	</dependency>
   </dependencies>
   <build>
       <plugins>

--- a/src/main/java/edu/wisc/my/restproxy/KeyUtils.java
+++ b/src/main/java/edu/wisc/my/restproxy/KeyUtils.java
@@ -6,10 +6,24 @@ import java.util.Map;
 import javax.servlet.http.HttpServletRequest;
 
 import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.core.env.Environment;
+import org.springframework.util.PropertyPlaceholderHelper;
 
-public class KeyUtils {
+import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.Multimap;
 
+public final class KeyUtils {
+
+  private static final String END_PLACEHOLDER = "}";
+  private static final String START_PLACEHOLDER = "{";
+
+  private KeyUtils() {
+  }
+  
+  private static final Logger logger = LoggerFactory.getLogger(KeyUtils.class);
+  
   public static Map<String, String> getHeaders(Environment env, HttpServletRequest request, String key) {
     HashMap <String, String> map = new HashMap<String, String>();
     String attributes = env.getProperty(key + ".attributes");
@@ -21,4 +35,55 @@ public class KeyUtils {
     return map;
   }
 
+  /**
+   * Utility method for extracting the Proxy Headers for a request.
+   * 
+   * The configuration option '{key}.proxyHeaders' is used to specify a multi-valued list of HTTP headers to add to the
+   * outbound request to '{key}.uri'. 
+   * 
+   * Example:
+   * <pre>
+   someservice.proxyHeaders=On-Behalf-Of: {wiscedupvi},Some-Other-Header: staticvalue
+   </pre>
+   * 
+   * Implementers can specify either static values ('Some-Other-Header: staticvalue') or use placeholders to relay 
+   * {@link HttpServletRequest#getAttribute(String)} values ('On-Behalf-Of: {wiscedupvi}')
+   * 
+   * @param env
+   * @param resourceKey
+   * @param request
+   * @return a potentially empty, but never null, {@link Multimap} of HTTP headers to add to the outbound HTTP request.
+   */
+  public static Multimap<String, String> getProxyHeaders(Environment env, String resourceKey, final HttpServletRequest request) {
+    Multimap<String, String> headers = ArrayListMultimap.create();
+    String proxyHeadersValue = env.getProperty(resourceKey + ".proxyHeaders");
+    if(proxyHeadersValue != null) {
+      String [] proxyHeaders = StringUtils.split(proxyHeadersValue, ",");
+      for(String proxyHeader: proxyHeaders) {
+        String [] tokens = StringUtils.trim(proxyHeader).split(":");
+        if(tokens.length == 2) {
+          PropertyPlaceholderHelper helper = new PropertyPlaceholderHelper(START_PLACEHOLDER, END_PLACEHOLDER);
+          String value = helper.replacePlaceholders(tokens[1], new PropertyPlaceholderHelper.PlaceholderResolver() {
+            @Override
+            public String resolvePlaceholder(String placeholderName) {
+              Object attribute = request.getAttribute(placeholderName);
+              if(attribute != null && attribute instanceof String) {
+                return (String) attribute;
+              }
+              logger.warn("configuration error: could not resolve placeholder for attribute {} as it's not a String, it's a {}", placeholderName, attribute != null ? attribute.getClass() : null);
+              return null;
+            }
+          });
+
+          value = StringUtils.trim(value);
+          if(value != null && !value.startsWith(START_PLACEHOLDER) && !value.endsWith(END_PLACEHOLDER)) {
+            headers.put(tokens[0], value);
+          }
+        } else {
+          logger.warn("configuration error: can't split {} on ':', ignoring", proxyHeader);
+        }
+      }
+    }
+    return headers;
+  }
 }

--- a/src/main/java/edu/wisc/my/restproxy/ProxyRequestContext.java
+++ b/src/main/java/edu/wisc/my/restproxy/ProxyRequestContext.java
@@ -1,0 +1,190 @@
+/**
+ * 
+ */
+package edu.wisc.my.restproxy;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.springframework.http.HttpMethod;
+
+import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.Multimap;
+
+/**
+ * Java Bean representing all of the context about a REST Request this library is proxying.
+ * 
+ * @author Nicholas Blair
+ */
+public class ProxyRequestContext {
+
+  private final String resourceKey;
+  private HttpMethod httpMethod = HttpMethod.GET;
+  private String uri;
+  private String username;
+  private byte[] password;
+  private Map<String, String> attributes = new HashMap<>();
+  private Multimap<String, String> headers = ArrayListMultimap.create();
+  /**
+   * 
+   * @param resourceKey required
+   */
+  public ProxyRequestContext(String resourceKey) {
+    this.resourceKey = resourceKey;
+  }
+  /**
+   * @return the resourceKey
+   */
+  public String getResourceKey() {
+    return resourceKey;
+  }
+  /**
+   * Defaults to {@link HttpMethod#GET} if not set explicitly.
+   * 
+   * @return the httpMethod
+   */
+  public HttpMethod getHttpMethod() {
+    return httpMethod;
+  }
+  /**
+   * @param httpMethod the httpMethod to set
+   */
+  public ProxyRequestContext setHttpMethod(HttpMethod httpMethod) {
+    this.httpMethod = httpMethod;
+    return this;
+  }
+  /**
+   * @return the the full URI (including scheme, host, port, path)
+   */
+  public String getUri() {
+    return uri;
+  }
+  /**
+   * @param uri the full URI (including scheme, host, port, path)
+   */
+  public ProxyRequestContext setUri(String uri) {
+    this.uri = uri;
+    return this;
+  }
+  /**
+   * @return the username
+   */
+  public String getUsername() {
+    return username;
+  }
+  /**
+   * @param username the username to set
+   */
+  public ProxyRequestContext setUsername(String username) {
+    this.username = username;
+    return this;
+  }
+  /**
+   * @return the password
+   */
+  public byte[] getPassword() {
+    return password;
+  }
+  /**
+   * @param password the password to set
+   */
+  public ProxyRequestContext setPassword(byte[] password) {
+    this.password = password;
+    return this;
+  }
+  /**
+   * @return the attributes
+   */
+  public Map<String, String> getAttributes() {
+    return attributes;
+  }
+  /**
+   * @param attributes the attributes to set
+   */
+  public ProxyRequestContext setAttributes(Map<String, String> attributes) {
+    this.attributes = attributes;
+    return this;
+  }
+  /**
+   * @return the headers
+   */
+  public Multimap<String, String> getHeaders() {
+    return headers;
+  }
+  /**
+   * @param headers the headers to set
+   */
+  public ProxyRequestContext setHeaders(Multimap<String, String> headers) {
+    this.headers = headers;
+    return this;
+  }
+  /* (non-Javadoc)
+   * @see java.lang.Object#toString()
+   */
+  @Override
+  public String toString() {
+    return "ProxyRequestContext [resourceKey=" + resourceKey + ", httpMethod=" + httpMethod
+        + ", uri=" + uri + ", username=" + username + ", password=" + ( password != null ? "<set, suppressed>" : "empty")
+        + ", attributes=" + attributes + ", headers=" + headers + "]";
+  }
+  /* (non-Javadoc)
+   * @see java.lang.Object#hashCode()
+   */
+  @Override
+  public int hashCode() {
+    final int prime = 31;
+    int result = 1;
+    result = prime * result + ((attributes == null) ? 0 : attributes.hashCode());
+    result = prime * result + ((headers == null) ? 0 : headers.hashCode());
+    result = prime * result + ((httpMethod == null) ? 0 : httpMethod.hashCode());
+    result = prime * result + Arrays.hashCode(password);
+    result = prime * result + ((resourceKey == null) ? 0 : resourceKey.hashCode());
+    result = prime * result + ((uri == null) ? 0 : uri.hashCode());
+    result = prime * result + ((username == null) ? 0 : username.hashCode());
+    return result;
+  }
+  /* (non-Javadoc)
+   * @see java.lang.Object#equals(java.lang.Object)
+   */
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj)
+      return true;
+    if (obj == null)
+      return false;
+    if (getClass() != obj.getClass())
+      return false;
+    ProxyRequestContext other = (ProxyRequestContext) obj;
+    if (attributes == null) {
+      if (other.attributes != null)
+        return false;
+    } else if (!attributes.equals(other.attributes))
+      return false;
+    if (headers == null) {
+      if (other.headers != null)
+        return false;
+    } else if (!headers.equals(other.headers))
+      return false;
+    if (httpMethod != other.httpMethod)
+      return false;
+    if (!Arrays.equals(password, other.password))
+      return false;
+    if (resourceKey == null) {
+      if (other.resourceKey != null)
+        return false;
+    } else if (!resourceKey.equals(other.resourceKey))
+      return false;
+    if (uri == null) {
+      if (other.uri != null)
+        return false;
+    } else if (!uri.equals(other.uri))
+      return false;
+    if (username == null) {
+      if (other.username != null)
+        return false;
+    } else if (!username.equals(other.username))
+      return false;
+    return true;
+  }
+}

--- a/src/main/java/edu/wisc/my/restproxy/api/GenericRestLookupController.java
+++ b/src/main/java/edu/wisc/my/restproxy/api/GenericRestLookupController.java
@@ -18,8 +18,12 @@ import org.springframework.web.bind.annotation.RestController;
 
 import edu.wisc.my.restproxy.KeyUtils;
 import edu.wisc.my.restproxy.service.GenericRestLookupService;
+import edu.wisc.my.restproxy.web.ResourceProxyController;
 
-
+/**
+ * @deprecated see {@link ResourceProxyController} instead
+ */
+@Deprecated
 @RestController
 @PropertySource("classpath:/endpoint.properties")
 public class GenericRestLookupController {

--- a/src/main/java/edu/wisc/my/restproxy/api/RestProxyConfiguration.java
+++ b/src/main/java/edu/wisc/my/restproxy/api/RestProxyConfiguration.java
@@ -1,0 +1,22 @@
+/**
+ * 
+ */
+package edu.wisc.my.restproxy.api;
+
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+
+/**
+ * {@link Configuration} activating necessary REST proxy services.
+ * 
+ * To use this class, simply {@link Import} it with the rest of your configuration.
+ * It's strongly suggested that your configuration provide a {@link org.springframework.web.client.RestTemplate} bean, but not required.
+ * 
+ * @author Nicholas Blair
+ */
+@Configuration
+@ComponentScan(value = {"edu.wisc.my.restproxy.dao", "edu.wisc.my.restproxy.service", "edu.wisc.my.restproxy.web" })
+public class RestProxyConfiguration {
+
+}

--- a/src/main/java/edu/wisc/my/restproxy/config/RestProxyConfiguration.java
+++ b/src/main/java/edu/wisc/my/restproxy/config/RestProxyConfiguration.java
@@ -1,7 +1,7 @@
 /**
  * 
  */
-package edu.wisc.my.restproxy.api;
+package edu.wisc.my.restproxy.config;
 
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;

--- a/src/main/java/edu/wisc/my/restproxy/dao/GenericRestLookupDao.java
+++ b/src/main/java/edu/wisc/my/restproxy/dao/GenericRestLookupDao.java
@@ -4,6 +4,10 @@ import java.util.Map;
 
 import org.springframework.http.HttpMethod;
 
+/**
+ * @deprecated see {@link RestProxyDao} instead
+ */
+@Deprecated
 public interface GenericRestLookupDao {
 
   /**

--- a/src/main/java/edu/wisc/my/restproxy/dao/RestProxyDao.java
+++ b/src/main/java/edu/wisc/my/restproxy/dao/RestProxyDao.java
@@ -1,0 +1,21 @@
+/**
+ * 
+ */
+package edu.wisc.my.restproxy.dao;
+
+import edu.wisc.my.restproxy.ProxyRequestContext;
+
+/**
+ * Data access interface for talking with a REST API.
+ * 
+ * @author Nicholas Blair
+ */
+public interface RestProxyDao {
+
+  /**
+   * 
+   * @param proxyRequestContext
+   * @return the response of the proxied request, serialized to an {@link Object}
+   */
+  public Object proxyRequest(ProxyRequestContext proxyRequestContext);
+}

--- a/src/main/java/edu/wisc/my/restproxy/dao/RestProxyDaoImpl.java
+++ b/src/main/java/edu/wisc/my/restproxy/dao/RestProxyDaoImpl.java
@@ -1,0 +1,61 @@
+/**
+ * 
+ */
+package edu.wisc.my.restproxy.dao;
+
+import java.util.Map.Entry;
+
+import org.apache.commons.codec.binary.Base64;
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+import edu.wisc.my.restproxy.ProxyRequestContext;
+
+/**
+ * {@link RestProxyDao} implementation backed by a {@link RestTemplate}.
+ * 
+ * A default instance is provided, but consumers are strongly recommended to configure
+ * their own instance and inject.
+ * 
+ * @author Nicholas Blair
+ */
+@Service
+public class RestProxyDaoImpl implements RestProxyDao {
+
+  @Autowired(required=false)
+  private RestTemplate restTemplate = new RestTemplate();
+  
+  private static final Logger logger = LoggerFactory.getLogger(RestProxyDaoImpl.class);
+  /* (non-Javadoc)
+   * @see edu.wisc.my.restproxy.dao.RestProxyDao#proxyRequest(edu.wisc.my.restproxy.ProxyRequestContext)
+   */
+  @Override
+  public Object proxyRequest(ProxyRequestContext context) {
+    HttpHeaders headers = new HttpHeaders();
+    if(StringUtils.isNotBlank(context.getUsername()) && null != context.getPassword()) {
+      String creds = context.getUsername() + ":" + context.getPassword();
+      byte[] base64CredsBytes = Base64.encodeBase64(creds.getBytes());
+      String base64Creds = new String(base64CredsBytes);
+      headers.add("Authorization", "Basic " + base64Creds);
+    }
+    
+    for(Entry<String, String> entry: context.getHeaders().entries()) {
+      headers.add(entry.getKey(), entry.getValue());
+    }
+    
+    HttpEntity<String> request = new HttpEntity<String>(headers);
+    ResponseEntity<Object> response = restTemplate.exchange(context.getUri(), 
+        context.getHttpMethod(), request, Object.class, context.getAttributes());
+    logger.trace("completed request for {}, response= {}", context, response);
+    Object responseBody = response.getBody();
+    return responseBody;
+  }
+
+}

--- a/src/main/java/edu/wisc/my/restproxy/service/GenericRestLookupService.java
+++ b/src/main/java/edu/wisc/my/restproxy/service/GenericRestLookupService.java
@@ -2,6 +2,10 @@ package edu.wisc.my.restproxy.service;
 
 import java.util.Map;
 
+/**
+ * @deprecated see {@link RestProxyService}
+ */
+@Deprecated
 public interface GenericRestLookupService {
   /**
    * Gets information from the provided key and attributes

--- a/src/main/java/edu/wisc/my/restproxy/service/RestProxyService.java
+++ b/src/main/java/edu/wisc/my/restproxy/service/RestProxyService.java
@@ -1,0 +1,25 @@
+/**
+ * 
+ */
+package edu.wisc.my.restproxy.service;
+
+import javax.servlet.http.HttpServletRequest;
+
+import edu.wisc.my.restproxy.ProxyRequestContext;
+
+/**
+ * Service interface for proxying a REST API.
+ * 
+ * @see ProxyRequestContext
+ * @author Nicholas Blair
+ */
+public interface RestProxyService {
+
+  /**
+   * 
+   * @param resourceKey
+   * @param request
+   * @return the Object returned from the REST API, serialized to an {@link Object} (may return null)
+   */
+  public Object proxyRequest(String resourceKey, HttpServletRequest request);
+}

--- a/src/main/java/edu/wisc/my/restproxy/service/RestProxyServiceImpl.java
+++ b/src/main/java/edu/wisc/my/restproxy/service/RestProxyServiceImpl.java
@@ -1,0 +1,111 @@
+/**
+ * 
+ */
+package edu.wisc.my.restproxy.service;
+
+import javax.servlet.http.HttpServletRequest;
+
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.env.Environment;
+import org.springframework.http.HttpMethod;
+import org.springframework.stereotype.Service;
+import org.springframework.util.PropertyPlaceholderHelper;
+import org.springframework.web.servlet.HandlerMapping;
+
+import edu.wisc.my.restproxy.KeyUtils;
+import edu.wisc.my.restproxy.ProxyRequestContext;
+import edu.wisc.my.restproxy.dao.RestProxyDao;
+
+/**
+ * Concrete implementation of {@link RestProxyService}.
+ *
+ * @author Nicholas Blair
+ */
+@Service
+public class RestProxyServiceImpl implements RestProxyService {
+
+  @Autowired
+  private Environment env;
+  @Autowired
+  private RestProxyDao proxyDao;
+  private static final Logger logger = LoggerFactory.getLogger(RestProxyServiceImpl.class);
+
+  /**
+   * Visible for testing. 
+   * 
+   * @param env the env to set
+   */
+  void setEnv(Environment env) {
+    this.env = env;
+  }
+  /**
+   * {@inheritDoc}
+   * 
+   * Inspects the {@link Environment} for necessary properties about the target API:
+   * <ul>
+   * <li>Resource root URI</li>
+   * <li>Credentials</li>
+   * </ul>
+   * 
+   * Delegates to {@link RestProxyDao#proxyRequest(ProxyRequestContext)}
+   */
+  @Override
+  public Object proxyRequest(final String resourceKey, final HttpServletRequest request) {
+    final String resourceRoot = env.getProperty(resourceKey + ".uri");
+    if(StringUtils.isBlank(resourceRoot)) {
+      logger.info("unknown resourceKey {}", resourceKey);
+      return null;
+    }
+    StringBuilder uri = new StringBuilder(resourceRoot);
+    
+    String resourcePath = (String) request.getAttribute( HandlerMapping.PATH_WITHIN_HANDLER_MAPPING_ATTRIBUTE );
+    if(StringUtils.isNotBlank(resourcePath)) {
+      if(!StringUtils.endsWith(uri, "/") && !resourcePath.startsWith("/")) {
+        uri.append("/");
+      }
+      uri.append(resourcePath);
+    }
+
+    String username = env.getProperty(resourceKey + ".username");
+    String password = env.getProperty(resourceKey + ".password");
+
+    ProxyRequestContext context = new ProxyRequestContext(resourceKey)
+      .setAttributes(KeyUtils.getHeaders(env, request, resourceKey))
+      .setHttpMethod(HttpMethod.valueOf(request.getMethod()))
+      .setPassword(password != null ? password.getBytes() : null)
+      .setUri(uri.toString())
+      .setUsername(username);
+
+    String proxyHeadersValue = env.getProperty(resourceKey + ".proxyHeaders");
+    if(proxyHeadersValue != null) {
+      String [] proxyHeaders = StringUtils.split(proxyHeadersValue, ",");
+      for(String proxyHeader: proxyHeaders) {
+        String [] tokens = proxyHeader.split(":");
+        if(tokens.length == 2) {
+          PropertyPlaceholderHelper helper = new PropertyPlaceholderHelper("{", "}");
+          String value = helper.replacePlaceholders(tokens[1], new PropertyPlaceholderHelper.PlaceholderResolver() {
+            @Override
+            public String resolvePlaceholder(String placeholderName) {
+              Object attribute = request.getAttribute(placeholderName);
+              if(attribute instanceof String) {
+                return (String) attribute;
+              }
+              logger.warn("configuration error: could not resolve placeholder for attribute {} as it's not a String, it's a {}", placeholderName, attribute.getClass());
+              return null;
+            }
+          });
+
+          context.getHeaders().put(tokens[0], StringUtils.trim(value));
+        } else {
+          logger.warn("configuration error: can't split {} on ':', ignoring", proxyHeader);
+        }
+      }
+    }
+    logger.debug("proxying request {}", context);
+    return proxyDao.proxyRequest(context);
+  }
+
+}

--- a/src/main/java/edu/wisc/my/restproxy/web/ResourceProxyController.java
+++ b/src/main/java/edu/wisc/my/restproxy/web/ResourceProxyController.java
@@ -1,0 +1,52 @@
+/**
+ * 
+ */
+package edu.wisc.my.restproxy.web;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.env.Environment;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.bind.annotation.RestController;
+
+import edu.wisc.my.restproxy.service.RestProxyService;
+
+/**
+ * {@link RestController} for proxying other REST resources.
+ * 
+ * @author Nicholas Blair
+ */
+@RestController
+public class ResourceProxyController {
+
+  @Autowired
+  private RestProxyService proxyService;
+  @Autowired
+  private Environment env;
+
+  /**
+   * @param env the env to set
+   */
+  void setEnv(Environment env) {
+    this.env = env;
+  }
+  /**
+   * 
+   */
+  @RequestMapping("/{key}/**")
+  public @ResponseBody Object proxyResource(HttpServletRequest request, 
+      HttpServletResponse response,
+      @PathVariable String key) {
+    Object result = proxyService.proxyRequest(key, request);     
+    if(result == null) {
+      response.setStatus(HttpServletResponse.SC_NOT_FOUND);
+      return null;
+    } else {
+      return result;
+    }
+  }
+}

--- a/src/main/resources/endpoint.properties.example
+++ b/src/main/resources/endpoint.properties.example
@@ -2,6 +2,7 @@
 #key.username           : the username to login to service (basic auth) *
 #key.password           : the password for the service (basic auth)     *
 #key.attributes         : the csv of attributes
+#key.proxyHeaders		: a comma separated list of headers to add output. Can put placeholders for values to get local request attributes.
 #key.cache              : how long to cache the information for that URI (with variables replaced) - not implemented yet
 #
 # * : not required
@@ -24,3 +25,8 @@ uwmadisonreddit.username=
 uwmadisonreddit.password=
 uwmadisonreddit.attributes=
 
+# proxyHeaders example
+someservice.uri=http://somewhere.wisc.edu/foo
+someservice.username=user
+someservice.password=pass
+someservice.proxyHeaders=On-Behalf-Of: {wiscedupvi},Some-Other-Header: staticvalue

--- a/src/test/java/edu/wisc/my/restproxy/KeyUtilsTest.java
+++ b/src/test/java/edu/wisc/my/restproxy/KeyUtilsTest.java
@@ -1,0 +1,75 @@
+/**
+ * 
+ */
+package edu.wisc.my.restproxy;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import javax.servlet.http.HttpServletRequest;
+
+import org.junit.Test;
+import org.springframework.core.env.Environment;
+import org.springframework.mock.env.MockEnvironment;
+import org.springframework.mock.web.MockHttpServletRequest;
+
+import com.google.common.collect.Multimap;
+
+/**
+ * Tests for {@link KeyUtils}.
+ * 
+ * @author Nicholas Blair
+ */
+public class KeyUtilsTest {
+
+  /**
+   * Verify stable behavior for {@link KeyUtils#getProxyHeaders(org.springframework.core.env.Environment, String, HttpServletRequest)}
+   * when no proxyHeaders configuration found in the {@link Environment}
+   */
+  @Test
+  public void getProxyHeaders_empty() {
+    assertTrue(KeyUtils.getProxyHeaders(new MockEnvironment(), "empty", new MockHttpServletRequest()).isEmpty());
+  }
+  /**
+   * Control experiment for {@link KeyUtils#getProxyHeaders(org.springframework.core.env.Environment, String, HttpServletRequest)}
+   * for simple proxyHeaders configuration: 1 static value.
+   */
+  @Test
+  public void getProxyHeaders_control() {
+    MockEnvironment env = new MockEnvironment();
+    env.setProperty("control.proxyHeaders", "foo: bar");
+    Multimap<String, String> proxyHeaders = KeyUtils.getProxyHeaders(env, "control", new MockHttpServletRequest());
+    assertEquals(1, proxyHeaders.get("foo").size());
+    assertEquals("bar", proxyHeaders.get("foo").iterator().next());
+  }
+  /**
+   * Experiment for {@link KeyUtils#getProxyHeaders(org.springframework.core.env.Environment, String, HttpServletRequest)}
+   * for proxyHeaders configuration with a placeholder.
+   */
+  @Test
+  public void getProxyHeaders_placeholder() {
+    MockEnvironment env = new MockEnvironment();
+    env.setProperty("placeholder.proxyHeaders", "foo: {bar}");
+    MockHttpServletRequest request = new MockHttpServletRequest();
+    request.setAttribute("bar", "banana");
+    Multimap<String, String> proxyHeaders = KeyUtils.getProxyHeaders(env, "placeholder", request);
+    assertEquals(1, proxyHeaders.get("foo").size());
+    assertEquals("banana", proxyHeaders.get("foo").iterator().next());
+  }
+  /**
+   * Experiment for {@link KeyUtils#getProxyHeaders(org.springframework.core.env.Environment, String, HttpServletRequest)}
+   * for proxyHeaders configuration with multiple HTTP headers: 1 placeholder, 1 static, and 1 unresolved.
+   */
+  @Test
+  public void getProxyHeaders_multiple() {
+    MockEnvironment env = new MockEnvironment();
+    env.setProperty("multiple.proxyHeaders", "foo: {bar}, one: two, unresolved: {notthere}");
+    MockHttpServletRequest request = new MockHttpServletRequest();
+    request.setAttribute("bar", "apple");
+    Multimap<String, String> proxyHeaders = KeyUtils.getProxyHeaders(env, "multiple", request);
+    assertEquals("apple", proxyHeaders.get("foo").iterator().next());
+    assertEquals("two", proxyHeaders.get("one").iterator().next());
+
+    assertTrue(proxyHeaders.get("unresolved").isEmpty());
+  }
+}

--- a/src/test/java/edu/wisc/my/restproxy/service/RestProxyServiceImplTest.java
+++ b/src/test/java/edu/wisc/my/restproxy/service/RestProxyServiceImplTest.java
@@ -1,0 +1,134 @@
+/**
+ * 
+ */
+package edu.wisc.my.restproxy.service;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.when;
+
+import javax.servlet.http.HttpServletRequest;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.springframework.mock.env.MockEnvironment;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.web.servlet.HandlerMapping;
+
+import edu.wisc.my.restproxy.ProxyRequestContext;
+import edu.wisc.my.restproxy.dao.RestProxyDao;
+
+/**
+ * Tests for {@link RestProxyServiceImpl}.
+ * 
+ * @author Nicholas Blair
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class RestProxyServiceImplTest {
+
+  private MockEnvironment env = new MockEnvironment();
+  @Mock private RestProxyDao proxyDao;
+  @InjectMocks private RestProxyServiceImpl proxy = new RestProxyServiceImpl();
+ 
+  @Before
+  public void setup() {
+      proxy.setEnv(env);
+  }
+  /**
+   * Control experiment for {@link RestProxyServiceImpl#proxyRequest(String, HttpServletRequest)}, confirms
+   * expected behavior for successful, simple request.
+   */
+  @Test
+  public void proxyRequest_control() {
+    final Object result = new Object();
+    
+    MockHttpServletRequest request = new MockHttpServletRequest();
+    request.setMethod("GET");
+    env.setProperty("control.uri", "http://localhost/foo");
+    ProxyRequestContext expected = new ProxyRequestContext("control").setUri("http://localhost/foo");
+    
+    when(proxyDao.proxyRequest(expected)).thenReturn(result);
+    assertEquals(result, proxy.proxyRequest("control", request));
+  }
+  
+  /**
+   * Experiment for {@link RestProxyServiceImpl#proxyRequest(String, HttpServletRequest)}, confirms
+   * expected behavior when the configuration contains credentials.
+   */
+  @Test
+  public void proxyRequest_withCredentials() {
+    final Object result = new Object();
+    
+    MockHttpServletRequest request = new MockHttpServletRequest();
+    request.setMethod("GET");
+    env.setProperty("withCredentials.uri", "http://localhost/foo");
+    env.setProperty("withCredentials.username", "user");
+    env.setProperty("withCredentials.password", "pass");
+    ProxyRequestContext expected = new ProxyRequestContext("withCredentials").setUri("http://localhost/foo")
+        .setUsername("user").setPassword("pass".getBytes());
+    
+    when(proxyDao.proxyRequest(expected)).thenReturn(result);
+    assertEquals(result, proxy.proxyRequest("withCredentials", request));
+  }
+  
+  /**
+   * Experiment for {@link RestProxyServiceImpl#proxyRequest(String, HttpServletRequest)}, confirms
+   * expected behavior when the configuration contains a request for additional headers with static values.
+   */
+  @Test
+  public void proxyRequest_withAdditionalHeader() {
+    final Object result = new Object();
+    
+    MockHttpServletRequest request = new MockHttpServletRequest();
+    request.setAttribute("wiscedupvi", "UW111A111");
+    request.setMethod("GET");
+    env.setProperty("withAdditionalHeaders.uri", "http://localhost/foo");
+    env.setProperty("withAdditionalHeaders.proxyHeaders", "Some-Header: staticvalue");
+    ProxyRequestContext expected = new ProxyRequestContext("withAdditionalHeaders").setUri("http://localhost/foo");
+    expected.getHeaders().put("Some-Header", "staticvalue");
+    
+    when(proxyDao.proxyRequest(expected)).thenReturn(result);
+    assertEquals(result, proxy.proxyRequest("withAdditionalHeaders", request));
+  }
+  /**
+   * Experiment for {@link RestProxyServiceImpl#proxyRequest(String, HttpServletRequest)}, confirms
+   * expected behavior when the configuration contains a request for additional headers, the values
+   * containing placeholders.
+   */
+  @Test
+  public void proxyRequest_withAdditionalHeaders_andPlaceholders() {
+    final Object result = new Object();
+    
+    MockHttpServletRequest request = new MockHttpServletRequest();
+    request.setAttribute("wiscedupvi", "UW111A111");
+    request.setMethod("GET");
+    env.setProperty("withAdditionalHeaders2.uri", "http://localhost/foo");
+    env.setProperty("withAdditionalHeaders2.proxyHeaders", "On-Behalf-Of: {wiscedupvi}");
+    ProxyRequestContext expected = new ProxyRequestContext("withAdditionalHeaders2").setUri("http://localhost/foo");
+    expected.getHeaders().put("On-Behalf-Of", "UW111A111");
+    
+    when(proxyDao.proxyRequest(expected)).thenReturn(result);
+    assertEquals(result, proxy.proxyRequest("withAdditionalHeaders2", request));
+  }
+  
+  /**
+   * Experiment for {@link RestProxyServiceImpl#proxyRequest(String, HttpServletRequest)}, confirms
+   * expected behavior when the request path contains additional fragments.
+   */
+  @Test
+  public void proxyRequest_withAdditionalPath() {
+    final Object result = new Object();
+    
+    MockHttpServletRequest request = new MockHttpServletRequest();
+    request.setMethod("GET");
+    request.setAttribute(HandlerMapping.PATH_WITHIN_HANDLER_MAPPING_ATTRIBUTE, "api/v2/employee/123");
+    env.setProperty("withAdditionalPath.uri", "http://localhost/foo");
+    ProxyRequestContext expected = new ProxyRequestContext("withAdditionalPath").setUri("http://localhost/foo/api/v2/employee/123");
+    
+    when(proxyDao.proxyRequest(expected)).thenReturn(result);
+    assertEquals(result, proxy.proxyRequest("withAdditionalPath", request));
+  }
+}

--- a/src/test/java/edu/wisc/my/restproxy/web/ResourceProxyControllerTest.java
+++ b/src/test/java/edu/wisc/my/restproxy/web/ResourceProxyControllerTest.java
@@ -1,0 +1,71 @@
+/**
+ * 
+ */
+package edu.wisc.my.restproxy.web;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.mockito.Mockito.when;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.springframework.mock.env.MockEnvironment;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+import edu.wisc.my.restproxy.service.RestProxyService;
+
+/**
+ * Tests for {@link ResourceProxyController}.
+ * 
+ * @author Nicholas Blair
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class ResourceProxyControllerTest {
+
+  private MockEnvironment env = new MockEnvironment();
+  @Mock private RestProxyService service;
+  @InjectMocks private ResourceProxyController controller = new ResourceProxyController();
+  
+  @Before
+  public void setup() {
+      controller.setEnv(env);
+  }
+  /**
+   * Experiment for {@link ResourceProxyController#proxyResource(HttpServletRequest, HttpServletResponse, String)}
+   * confirming behavior when "key" path variable not found in environment.
+   */
+  @Test
+  public void proxyResource_keyNotFound() {
+      MockHttpServletRequest request = new MockHttpServletRequest();
+      MockHttpServletResponse response = new MockHttpServletResponse();
+      
+      assertNull(controller.proxyResource(request, response, "bogus"));
+      assertEquals(HttpServletResponse.SC_NOT_FOUND, response.getStatus());
+  }
+  /**
+   * Control experiment for {@link ResourceProxyController#proxyResource(HttpServletRequest, HttpServletResponse, String)}
+   * confirm behavior when "key" argument contains a known key and no additional path elements underneath.
+   */
+  @Test
+  public void proxyResource_control() {
+      Object result = new Object();
+      final String resourceKey = "something";
+      
+      HttpServletRequest request = new MockHttpServletRequest();
+      when(service.proxyRequest(resourceKey, request)).thenReturn(result);
+      
+      env.setProperty("something.uri", "http://localhost/something");
+      
+      MockHttpServletResponse response = new MockHttpServletResponse();
+      
+      assertEquals(result, controller.proxyResource(request, response, "something"));
+  }
+}


### PR DESCRIPTION
This pull request introduces a new Controller/Service/Dao API to extend our ability to proxy REST resources. The impetus for this pull request is issue #9.

This new API:
- Simplifies the Controller to just binding HTTP requests to the service tier.
- Allows for proxying resources with more flexible pathing.
- Gives the service tier the job of reading configuration and delegating to the DAO.
- Adds a 'key.proxyHeaders' feature that can bind local HTTP request attributes to outbound HTTP request headers.
- Gives the DAO a new data model.

Bonus - a Spring `@Configuration` class is added for downstream consumers to simply `@Import`.

The existing Controller/Service/Dao interfaces are unmodified and have been marked with `@Deprecated`.
