### PR TITLE
Proxy'd Requests resulting in '401 Bad Credentials'

### DIFF
--- a/src/main/java/edu/wisc/my/restproxy/ProxyRequestContext.java
+++ b/src/main/java/edu/wisc/my/restproxy/ProxyRequestContext.java
@@ -23,7 +23,7 @@ public class ProxyRequestContext {
   private HttpMethod httpMethod = HttpMethod.GET;
   private String uri;
   private String username;
-  private byte[] password;
+  private String password;
   private Map<String, String> attributes = new HashMap<>();
   private Multimap<String, String> headers = ArrayListMultimap.create();
   /**
@@ -83,13 +83,13 @@ public class ProxyRequestContext {
   /**
    * @return the password
    */
-  public byte[] getPassword() {
+  public String getPassword() {
     return password;
   }
   /**
    * @param password the password to set
    */
-  public ProxyRequestContext setPassword(byte[] password) {
+  public ProxyRequestContext setPassword(String password) {
     this.password = password;
     return this;
   }
@@ -138,7 +138,7 @@ public class ProxyRequestContext {
     result = prime * result + ((attributes == null) ? 0 : attributes.hashCode());
     result = prime * result + ((headers == null) ? 0 : headers.hashCode());
     result = prime * result + ((httpMethod == null) ? 0 : httpMethod.hashCode());
-    result = prime * result + Arrays.hashCode(password);
+    result = prime * result + ((password == null) ? 0 : password.hashCode());
     result = prime * result + ((resourceKey == null) ? 0 : resourceKey.hashCode());
     result = prime * result + ((uri == null) ? 0 : uri.hashCode());
     result = prime * result + ((username == null) ? 0 : username.hashCode());
@@ -168,7 +168,10 @@ public class ProxyRequestContext {
       return false;
     if (httpMethod != other.httpMethod)
       return false;
-    if (!Arrays.equals(password, other.password))
+    if (password == null) {
+      if (other.password != null)
+        return false;
+    } else if (!password.equals(other.password))
       return false;
     if (resourceKey == null) {
       if (other.resourceKey != null)
@@ -187,4 +190,5 @@ public class ProxyRequestContext {
       return false;
     return true;
   }
+  
 }

--- a/src/main/java/edu/wisc/my/restproxy/dao/RestProxyDaoImpl.java
+++ b/src/main/java/edu/wisc/my/restproxy/dao/RestProxyDaoImpl.java
@@ -40,7 +40,10 @@ public class RestProxyDaoImpl implements RestProxyDao {
   public Object proxyRequest(ProxyRequestContext context) {
     HttpHeaders headers = new HttpHeaders();
     if(StringUtils.isNotBlank(context.getUsername()) && null != context.getPassword()) {
-      String creds = context.getUsername() + ":" + context.getPassword();
+      StringBuffer credsBuffer = new StringBuffer(context.getUsername());
+      credsBuffer.append(":");
+      credsBuffer.append(context.getPassword());
+      String creds = credsBuffer.toString();
       byte[] base64CredsBytes = Base64.encodeBase64(creds.getBytes());
       String base64Creds = new String(base64CredsBytes);
       headers.add("Authorization", "Basic " + base64Creds);

--- a/src/main/java/edu/wisc/my/restproxy/service/RestProxyServiceImpl.java
+++ b/src/main/java/edu/wisc/my/restproxy/service/RestProxyServiceImpl.java
@@ -55,7 +55,7 @@ public class RestProxyServiceImpl implements RestProxyService {
    */
   @Override
   public Object proxyRequest(final String resourceKey, final HttpServletRequest request) {
-    final String resourceRoot = env.getProperty(resourceKey + ".uri");
+    final String resourceRoot = env.getProperty(resourceKey + ".uri"); 
     if(StringUtils.isBlank(resourceRoot)) {
       logger.info("unknown resourceKey {}", resourceKey);
       return null;
@@ -76,7 +76,7 @@ public class RestProxyServiceImpl implements RestProxyService {
     ProxyRequestContext context = new ProxyRequestContext(resourceKey)
       .setAttributes(KeyUtils.getHeaders(env, request, resourceKey))
       .setHttpMethod(HttpMethod.valueOf(request.getMethod()))
-      .setPassword(password != null ? password.getBytes() : null)
+      .setPassword(password)
       .setHeaders(KeyUtils.getProxyHeaders(env, resourceKey, request))
       .setUri(uri.toString())
       .setUsername(username);
@@ -84,5 +84,4 @@ public class RestProxyServiceImpl implements RestProxyService {
     logger.debug("proxying request {}", context);
     return proxyDao.proxyRequest(context);
   }
-
 }

--- a/src/test/java/edu/wisc/my/restproxy/dao/RestProxyDaoImplTest.java
+++ b/src/test/java/edu/wisc/my/restproxy/dao/RestProxyDaoImplTest.java
@@ -1,0 +1,100 @@
+/**
+ * 
+ */
+package edu.wisc.my.restproxy.dao;
+
+import static org.junit.Assert.assertEquals;
+
+import org.apache.commons.codec.binary.Base64;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Matchers;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.mock.env.MockEnvironment;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.web.client.RestTemplate;
+
+import edu.wisc.my.restproxy.KeyUtils;
+import edu.wisc.my.restproxy.ProxyRequestContext;
+
+/**
+ * Tests for {@link RestProxyDaoImpl}.
+ * 
+ * @author Collin Cudd
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class RestProxyDaoImplTest {
+
+  private MockEnvironment env = new MockEnvironment();
+  @Mock private RestTemplate restTemplate;
+  @InjectMocks private RestProxyDaoImpl proxyDao = new RestProxyDaoImpl();
+  
+  @Mock
+  ResponseEntity<Object> expectedResponse;
+  
+  /**
+   * @return {@link ProxyRequestContext}.
+   */
+  protected ProxyRequestContext getContext() {
+    String resourceKey = "proxytest";
+    MockHttpServletRequest request = new MockHttpServletRequest();
+    request.setMethod("GET");
+    
+    ProxyRequestContext context = new ProxyRequestContext(resourceKey)
+    .setAttributes(KeyUtils.getHeaders(env, request, resourceKey))
+    .setHttpMethod(HttpMethod.valueOf(request.getMethod()))
+    .setPassword("foopass")
+    .setHeaders(KeyUtils.getProxyHeaders(env, resourceKey, request))
+    .setUri("localhost:8080/foo")
+    .setUsername("foouser");
+    
+    return context;
+  }
+  
+  /**
+   * Control test for {@link RestProxyDaoImpl#proxyRequest(ProxyRequestContext)}
+   */
+  @Test
+  public void proxyRequest_control() {
+    ProxyRequestContext context = getContext();
+    HttpHeaders headers = new HttpHeaders();
+    StringBuffer credsBuffer = new StringBuffer(context.getUsername());
+    credsBuffer.append(":");
+    credsBuffer.append(context.getPassword());
+    String creds = credsBuffer.toString();
+    byte[] base64CredsBytes = Base64.encodeBase64(creds.getBytes());
+    String base64Creds = new String(base64CredsBytes);
+    headers.add("Authorization", "Basic " + base64Creds);
+    
+    HttpEntity<String> expectedRequest = new HttpEntity<String>(headers);
+    Object expectedResponseBody = Mockito.mock(Object.class);
+    Mockito.when(expectedResponse.getBody()).thenReturn(expectedResponseBody);
+    
+    Mockito.when(
+        restTemplate.exchange(
+            Matchers.eq(context.getUri()), 
+            Matchers.eq(context.getHttpMethod()), 
+            Matchers.eq(expectedRequest),
+            Matchers.eq(Object.class), 
+            Matchers.eq(context.getAttributes())
+        )
+    ).thenReturn(expectedResponse);
+
+    Object proxyResponse = proxyDao.proxyRequest(context);
+    Mockito.verify(restTemplate).exchange(
+        Matchers.eq(context.getUri()), 
+        Matchers.eq(context.getHttpMethod()), 
+        Matchers.eq(expectedRequest),
+        Matchers.eq(Object.class), 
+        Matchers.eq(context.getAttributes())
+    );
+    assertEquals(expectedResponseBody, proxyResponse);
+    }
+}

--- a/src/test/java/edu/wisc/my/restproxy/service/RestProxyServiceImplTest.java
+++ b/src/test/java/edu/wisc/my/restproxy/service/RestProxyServiceImplTest.java
@@ -68,7 +68,7 @@ public class RestProxyServiceImplTest {
     env.setProperty("withCredentials.username", "user");
     env.setProperty("withCredentials.password", "pass");
     ProxyRequestContext expected = new ProxyRequestContext("withCredentials").setUri("http://localhost/foo")
-        .setUsername("user").setPassword("pass".getBytes());
+        .setUsername("user").setPassword("pass");
     
     when(proxyDao.proxyRequest(expected)).thenReturn(result);
     assertEquals(result, proxy.proxyRequest("withCredentials", request));


### PR DESCRIPTION
RextProxyDaoImpl.proxyRequest uses the username and password field to construct an Auth header.  If password is a byte[], the following line is going to produce unexpected results and your proxy'd request is most likely going to encounter a 401 Bad Credentials.

String creds = context.getUsername() + ":" + context.getPassword();
// the value of creds is going to be something like: 'admin:[B@106d69c'

This PR changes the type of the password field on ProxyRequestContext from a byte[] to a String and gets you past those nasty 401 errors.  
