### PR TITLE
Strip the resourceKey from the proxy'd uri.

### DIFF
--- a/src/main/java/edu/wisc/my/restproxy/service/RestProxyServiceImpl.java
+++ b/src/main/java/edu/wisc/my/restproxy/service/RestProxyServiceImpl.java
@@ -64,6 +64,9 @@ public class RestProxyServiceImpl implements RestProxyService {
     
     String resourcePath = (String) request.getAttribute( HandlerMapping.PATH_WITHIN_HANDLER_MAPPING_ATTRIBUTE );
     if(StringUtils.isNotBlank(resourcePath)) {
+      if(resourcePath.startsWith("/"+resourceKey)) {
+        resourcePath = resourcePath.replaceFirst("/"+resourceKey, "");
+      }
       if(!StringUtils.endsWith(uri, "/") && !resourcePath.startsWith("/")) {
         uri.append("/");
       }

--- a/src/test/java/edu/wisc/my/restproxy/service/RestProxyServiceImplTest.java
+++ b/src/test/java/edu/wisc/my/restproxy/service/RestProxyServiceImplTest.java
@@ -47,8 +47,11 @@ public class RestProxyServiceImplTest {
     
     MockHttpServletRequest request = new MockHttpServletRequest();
     request.setMethod("GET");
-    env.setProperty("control.uri", "http://localhost/foo");
-    ProxyRequestContext expected = new ProxyRequestContext("control").setUri("http://localhost/foo");
+    request.setAttribute(HandlerMapping.PATH_WITHIN_HANDLER_MAPPING_ATTRIBUTE, "/control/foo");
+    env.setProperty("control.uri", "http://destination");
+
+    //note the resourceKey ('control' in this context) is stripped from the uri
+    ProxyRequestContext expected = new ProxyRequestContext("control").setUri("http://destination/foo");
     
     when(proxyDao.proxyRequest(expected)).thenReturn(result);
     assertEquals(result, proxy.proxyRequest("control", request));


### PR DESCRIPTION
If your configuration is:
star.uri=localhost:8081

And your application performs a 'Get' request to /proxy/star/foo
Your proxied request will be sent to: localhost:8081/star/foo

This works great, however it's not always desirable for the proxied uri to start with your resourceKey.  Say for example, the application on the receiving end of your proxied request is served from "/" and NOT "/resourceKey".

This PR resolves the above pathing issues by striping the resourceKey from the uri of your proxied request.  In other words, assuming the same config as above:

Your application performs a 'Get' request to /proxy/star/foo
Your proxied request will be sent to: localhost:8081/foo
