### PR TITLE
Adds support for proxying request body (if 'application/json')

### DIFF
--- a/src/main/java/edu/wisc/my/restproxy/ProxyRequestContext.java
+++ b/src/main/java/edu/wisc/my/restproxy/ProxyRequestContext.java
@@ -3,7 +3,6 @@
  */
 package edu.wisc.my.restproxy;
 
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -26,6 +25,7 @@ public class ProxyRequestContext {
   private String password;
   private Map<String, String> attributes = new HashMap<>();
   private Multimap<String, String> headers = ArrayListMultimap.create();
+  private RequestBody requestBody;
   /**
    * 
    * @param resourceKey required
@@ -117,6 +117,19 @@ public class ProxyRequestContext {
    */
   public ProxyRequestContext setHeaders(Multimap<String, String> headers) {
     this.headers = headers;
+    return this;
+  }
+  /**
+   * @return the requestBody
+   */
+  public RequestBody getRequestBody() {
+    return requestBody;
+  }
+  /**
+   * @param requestBody the requestBody to set
+   */
+  public ProxyRequestContext setRequestBody(RequestBody requestBody) {
+    this.requestBody = requestBody;
     return this;
   }
   /* (non-Javadoc)

--- a/src/main/java/edu/wisc/my/restproxy/RequestBody.java
+++ b/src/main/java/edu/wisc/my/restproxy/RequestBody.java
@@ -10,18 +10,18 @@ package edu.wisc.my.restproxy;
  */
 public class RequestBody {
 
-  private Object body;
+  private byte[] body;
   private String contentType;
   /**
    * @return the body
    */
-  public Object getBody() {
+  public byte[] getBody() {
     return body;
   }
   /**
    * @param body the body to set
    */
-  public RequestBody setBody(Object body) {
+  public RequestBody setBody(byte[] body) {
     this.body = body;
     return this;
   }

--- a/src/main/java/edu/wisc/my/restproxy/RequestBody.java
+++ b/src/main/java/edu/wisc/my/restproxy/RequestBody.java
@@ -1,0 +1,48 @@
+/**
+ * 
+ */
+package edu.wisc.my.restproxy;
+
+/**
+ * Bean to represent a request body.
+ * 
+ * @author Nicholas Blair
+ */
+public class RequestBody {
+
+  private Object body;
+  private String contentType;
+  /**
+   * @return the body
+   */
+  public Object getBody() {
+    return body;
+  }
+  /**
+   * @param body the body to set
+   */
+  public RequestBody setBody(Object body) {
+    this.body = body;
+    return this;
+  }
+  /**
+   * @return the contentType
+   */
+  public String getContentType() {
+    return contentType;
+  }
+  /**
+   * @param contentType the contentType to set
+   */
+  public RequestBody setContentType(String contentType) {
+    this.contentType = contentType;
+    return this;
+  }
+  /* (non-Javadoc)
+   * @see java.lang.Object#toString()
+   */
+  @Override
+  public String toString() {
+    return "RequestBody [body=" + body + ", contentType=" + contentType + "]";
+  }
+}

--- a/src/main/java/edu/wisc/my/restproxy/dao/RestProxyDaoImpl.java
+++ b/src/main/java/edu/wisc/my/restproxy/dao/RestProxyDaoImpl.java
@@ -53,7 +53,8 @@ public class RestProxyDaoImpl implements RestProxyDao {
       headers.add(entry.getKey(), entry.getValue());
     }
     
-    HttpEntity<String> request = new HttpEntity<String>(headers);
+    HttpEntity<Object> request = context.getRequestBody() == null ? new HttpEntity<Object>(headers) : new HttpEntity<Object>(context.getRequestBody().getBody(), headers);
+    
     ResponseEntity<Object> response = restTemplate.exchange(context.getUri(), 
         context.getHttpMethod(), request, Object.class, context.getAttributes());
     logger.trace("completed request for {}, response= {}", context, response);

--- a/src/test/java/edu/wisc/my/restproxy/service/RestProxyServiceImplTest.java
+++ b/src/test/java/edu/wisc/my/restproxy/service/RestProxyServiceImplTest.java
@@ -4,6 +4,8 @@
 package edu.wisc.my.restproxy.service;
 
 import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import javax.servlet.http.HttpServletRequest;
@@ -133,5 +135,37 @@ public class RestProxyServiceImplTest {
     
     when(proxyDao.proxyRequest(expected)).thenReturn(result);
     assertEquals(result, proxy.proxyRequest("withAdditionalPath", request));
+  }
+  /**
+   * Experiment for {@link RestProxyServiceImpl#proxyRequest(String, HttpServletRequest)}
+   * where the request has a 'application/json' body.
+   */
+  @Test
+  public void proxyRequest_withRequestBody() { 
+    MockHttpServletRequest request = new MockHttpServletRequest();
+    request.setMethod("PUT");
+    request.setAttribute(HandlerMapping.PATH_WITHIN_HANDLER_MAPPING_ATTRIBUTE, "/withRequestBody/foo");
+    request.setContent("{ \"hello\": \"world\" }".getBytes());
+    request.addHeader("Content-Type", "application/json");
+    env.setProperty("withRequestBody.uri", "http://destination");
+
+    proxy.proxyRequest("withRequestBody", request);
+    verify(proxyDao).proxyRequest(any(ProxyRequestContext.class));
+  }
+  /**
+   * Experiment for {@link RestProxyServiceImpl#proxyRequest(String, HttpServletRequest)}
+   * where the request has a body but not the 'application/json' content-type.
+   */
+  @Test
+  public void proxyRequest_withRequestBody_notjson() { 
+    MockHttpServletRequest request = new MockHttpServletRequest();
+    request.setMethod("PUT");
+    request.setAttribute(HandlerMapping.PATH_WITHIN_HANDLER_MAPPING_ATTRIBUTE, "/notjson/foo");
+    request.setContent("<html></html>".getBytes());
+    request.addHeader("Content-Type", "text/html");
+    env.setProperty("notjson.uri", "http://destination");
+
+    proxy.proxyRequest("notjson", request);
+    verify(proxyDao).proxyRequest(any(ProxyRequestContext.class));
   }
 }


### PR DESCRIPTION
This pull request should provide some help for Issue #15. If the request has 'application/json' Content-Type, we attempt to deserialize the `HttpServletRequest#getInputStream` using Jackson's ObjectMapper. If successful, we pass that content down into the RequestDao and off to the RestTemplate.

I've got some unit tests here, but I'm thinking we're actually going to have to test this against a real service to get confirmation that the issue is resolved.
