### PR TITLE
Forward Response Content AND Status

### DIFF
--- a/src/main/java/edu/wisc/my/restproxy/dao/RestProxyDao.java
+++ b/src/main/java/edu/wisc/my/restproxy/dao/RestProxyDao.java
@@ -3,6 +3,8 @@
  */
 package edu.wisc.my.restproxy.dao;
 
+import org.springframework.http.ResponseEntity;
+
 import edu.wisc.my.restproxy.ProxyRequestContext;
 
 /**
@@ -13,9 +15,8 @@ import edu.wisc.my.restproxy.ProxyRequestContext;
 public interface RestProxyDao {
 
   /**
-   * 
    * @param proxyRequestContext
-   * @return the response of the proxied request, serialized to an {@link Object}
+   * @return the {@link ResponseEntity} of the proxied request.
    */
-  public Object proxyRequest(ProxyRequestContext proxyRequestContext);
+  public ResponseEntity<Object> proxyRequest(ProxyRequestContext proxyRequestContext);
 }

--- a/src/main/java/edu/wisc/my/restproxy/dao/RestProxyResponseErrorHandler.java
+++ b/src/main/java/edu/wisc/my/restproxy/dao/RestProxyResponseErrorHandler.java
@@ -1,0 +1,43 @@
+/**
+ * 
+ */
+package edu.wisc.my.restproxy.dao;
+
+import java.io.IOException;
+
+import org.springframework.http.client.ClientHttpRequest;
+import org.springframework.http.client.ClientHttpResponse;
+import org.springframework.web.client.ResponseErrorHandler;
+
+/**
+ * {@link ResponseErrorHandler} implementation that does nothing and considers every
+ * {@link ClientHttpRequest} a success.
+ * 
+ * This class does nothing because RestProxy is responsible soley for relaying requests and
+ * responses. We don't care what's in the response, we just forward it on. It's up to the client to deal
+ * with responses, whether they're successes or errors.
+ * 
+ * @author Collin Cudd
+ */
+public class RestProxyResponseErrorHandler implements ResponseErrorHandler {
+
+  /*
+   * (non-Javadoc)
+   * 
+   * @see
+   * org.springframework.web.client.ResponseErrorHandler#handleError(org.springframework.http.client
+   * .ClientHttpResponse)
+   */
+  @Override
+  public void handleError(ClientHttpResponse response) throws IOException {
+    //no-op
+  }
+
+  /* (non-Javadoc)
+   * @see org.springframework.web.client.ResponseErrorHandler#hasError(org.springframework.http.client.ClientHttpResponse)
+   */
+  @Override
+  public boolean hasError(ClientHttpResponse response) throws IOException {
+    return false;
+  }
+}

--- a/src/main/java/edu/wisc/my/restproxy/service/RestProxyService.java
+++ b/src/main/java/edu/wisc/my/restproxy/service/RestProxyService.java
@@ -5,6 +5,8 @@ package edu.wisc.my.restproxy.service;
 
 import javax.servlet.http.HttpServletRequest;
 
+import org.springframework.http.ResponseEntity;
+
 import edu.wisc.my.restproxy.ProxyRequestContext;
 
 /**
@@ -19,7 +21,7 @@ public interface RestProxyService {
    * 
    * @param resourceKey
    * @param request
-   * @return the Object returned from the REST API, serialized to an {@link Object} (may return null)
+   * @return the {@link ResponseEntity} returned from the REST API (may return null)
    */
-  public Object proxyRequest(String resourceKey, HttpServletRequest request);
+  public ResponseEntity<Object> proxyRequest(String resourceKey, HttpServletRequest request);
 }

--- a/src/main/java/edu/wisc/my/restproxy/web/ResourceProxyController.java
+++ b/src/main/java/edu/wisc/my/restproxy/web/ResourceProxyController.java
@@ -37,23 +37,27 @@ public class ResourceProxyController {
   void setEnv(Environment env) {
     this.env = env;
   }
+
   /**
+   * Proxies the request and then calls {@link HttpServletResponse#setStatus(int)} with the
+   * {@link HttpStatus} recieved. If the proxy response contains content it's simply returned here
+   * as an {@link Object}.
    * 
+   * @param request
+   * @param response
+   * @param key
+   * @return the body of the proxy response or null.
    */
   @RequestMapping("/{key}/**")
   public  @ResponseBody Object proxyResource(HttpServletRequest request, 
       HttpServletResponse response,
       @PathVariable String key) {
     ResponseEntity<Object> responseEntity = proxyService.proxyRequest(key, request);   
-    if(responseEntity != null) {
-      HttpStatus statusCode = responseEntity.getStatusCode();
-      response.setStatus(statusCode.value());
-      if(responseEntity.hasBody()) {
-        return responseEntity.getBody();
-      }
-    }else {
+    if(responseEntity == null || responseEntity.getStatusCode() == null) {
       response.setStatus(HttpStatus.NOT_FOUND.value());
+      return null;
     }
-    return null;    
+    response.setStatus(responseEntity.getStatusCode().value());
+    return responseEntity.hasBody() ? responseEntity.getBody() : null;  
   }
 }

--- a/src/main/java/edu/wisc/my/restproxy/web/ResourceProxyController.java
+++ b/src/main/java/edu/wisc/my/restproxy/web/ResourceProxyController.java
@@ -8,6 +8,9 @@ import javax.servlet.http.HttpServletResponse;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.env.Environment;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseBody;
@@ -20,7 +23,7 @@ import edu.wisc.my.restproxy.service.RestProxyService;
  * 
  * @author Nicholas Blair
  */
-@RestController
+@Controller
 public class ResourceProxyController {
 
   @Autowired
@@ -38,15 +41,19 @@ public class ResourceProxyController {
    * 
    */
   @RequestMapping("/{key}/**")
-  public @ResponseBody Object proxyResource(HttpServletRequest request, 
+  public  @ResponseBody Object proxyResource(HttpServletRequest request, 
       HttpServletResponse response,
       @PathVariable String key) {
-    Object result = proxyService.proxyRequest(key, request);     
-    if(result == null) {
-      response.setStatus(HttpServletResponse.SC_NOT_FOUND);
-      return null;
-    } else {
-      return result;
+    ResponseEntity<Object> responseEntity = proxyService.proxyRequest(key, request);   
+    if(responseEntity != null) {
+      HttpStatus statusCode = responseEntity.getStatusCode();
+      response.setStatus(statusCode.value());
+      if(responseEntity.hasBody()) {
+        return responseEntity.getBody();
+      }
+    }else {
+      response.setStatus(HttpStatus.NOT_FOUND.value());
     }
+    return null;    
   }
 }

--- a/src/test/java/edu/wisc/my/restproxy/ValidationResult.java
+++ b/src/test/java/edu/wisc/my/restproxy/ValidationResult.java
@@ -1,0 +1,23 @@
+/**
+ * 
+ */
+package edu.wisc.my.restproxy;
+
+/**
+ * Just an example of an object that could be retruned by rest api.
+ * @author Collin Cudd
+ */
+public class ValidationResult {
+
+  boolean success;
+  String message;
+  /**
+   * @param success
+   * @param message
+   */
+  public ValidationResult(boolean success, String message) {
+    this.success = success;
+    this.message = message;
+  }
+  
+}

--- a/src/test/java/edu/wisc/my/restproxy/dao/RestProxyDaoImplTest.java
+++ b/src/test/java/edu/wisc/my/restproxy/dao/RestProxyDaoImplTest.java
@@ -74,9 +74,6 @@ public class RestProxyDaoImplTest {
     headers.add("Authorization", "Basic " + base64Creds);
     
     HttpEntity<String> expectedRequest = new HttpEntity<String>(headers);
-    Object expectedResponseBody = Mockito.mock(Object.class);
-    Mockito.when(expectedResponse.getBody()).thenReturn(expectedResponseBody);
-    
     Mockito.when(
         restTemplate.exchange(
             Matchers.eq(context.getUri()), 
@@ -95,6 +92,6 @@ public class RestProxyDaoImplTest {
         Matchers.eq(Object.class), 
         Matchers.eq(context.getAttributes())
     );
-    assertEquals(expectedResponseBody, proxyResponse);
+    assertEquals(expectedResponse, proxyResponse);
     }
 }

--- a/src/test/java/edu/wisc/my/restproxy/web/ResourceProxyControllerTest.java
+++ b/src/test/java/edu/wisc/my/restproxy/web/ResourceProxyControllerTest.java
@@ -16,10 +16,13 @@ import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.mock.env.MockEnvironment;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 
+import edu.wisc.my.restproxy.ValidationResult;
 import edu.wisc.my.restproxy.service.RestProxyService;
 
 /**
@@ -56,16 +59,36 @@ public class ResourceProxyControllerTest {
    */
   @Test
   public void proxyResource_control() {
-      Object result = new Object();
+      final ResponseEntity<Object> result = new ResponseEntity<Object>(new Object(), HttpStatus.OK);
       final String resourceKey = "something";
-      
-      HttpServletRequest request = new MockHttpServletRequest();
-      when(service.proxyRequest(resourceKey, request)).thenReturn(result);
-      
       env.setProperty("something.uri", "http://localhost/something");
       
+      HttpServletRequest request = new MockHttpServletRequest();
       MockHttpServletResponse response = new MockHttpServletResponse();
+      when(service.proxyRequest(resourceKey, request)).thenReturn(result);
       
-      assertEquals(result, controller.proxyResource(request, response, "something"));
+      assertEquals(result.getBody(), controller.proxyResource(request, response, "something"));
+      assertEquals(HttpStatus.OK, result.getStatusCode());
+      assertEquals(HttpStatus.OK.value(), response.getStatus());
+  }
+  
+  /**
+   * Simulates a call to {@link ResourceProxyController#proxyResource(HttpServletRequest, HttpServletResponse, String)} encountering a 400.
+   * Test verifies the httpstatus and body (a {@link ValidationResult} in this case) are passed back to the client.
+   */
+  @Test
+  public void proxyResource_badRequest() {
+    ValidationResult validationFailure = new ValidationResult(false, "you didn't check the box");
+    final ResponseEntity<Object> expected = new ResponseEntity<Object>(validationFailure, HttpStatus.BAD_REQUEST);
+    final String resourceKey = "something"; 
+    HttpServletRequest request = new MockHttpServletRequest();
+    when(service.proxyRequest(resourceKey, request)).thenReturn(expected);
+    
+    env.setProperty("something.uri", "http://localhost/something");
+    
+    MockHttpServletResponse response = new MockHttpServletResponse();
+    
+    assertEquals(expected.getBody(), controller.proxyResource(request, response, "something"));
+    assertEquals(HttpStatus.BAD_REQUEST.value(), response.getStatus());
   }
 }


### PR DESCRIPTION
Modify service and dao layers to return a ResponseEntity<Object> instead of just an Object.

Returning an object is not sufficient as many REST api calls use HTTP status alone to indicate the success, or failure, of an operation (i.e. 204 No Content).

I've also added RestProxyResponseErrorHandler, a ResponseErrorHandler which is always used and does nothing, but it does highlight some important assumptions:
RestProxy's sole responsibility is to relay requests and responses.
It's up to the client to deal with responses, whether they are successes or errors.

RestProxyServiceImpl has also been modified to allow any content type and to only attach a body when the request has a content length greater than zero.
