### PR TITLE
Update standalone service to work with latest grails

### DIFF
--- a/Application.groovy
+++ b/Application.groovy
@@ -1,7 +1,6 @@
-@Grab("edu.wisc.my.restproxy:json-proxy-service:1.0")
+@Grab("edu.wisc.my.restproxy:json-proxy-service:1.1.6-SNAPSHOT")
 
 @ComponentScan("edu.wisc.my.restproxy")
 @RestController
-@RequestMapping("/")
-class ProxyService extends edu.wisc.my.restproxy.api.GenericRestLookupController {}
+class ProxyService {}
 

--- a/application.yml
+++ b/application.yml
@@ -6,7 +6,7 @@ info:
     app:
         name: proxy-service
         version: 0.1
-        grailsVersion: 3.0.2
+        grailsVersion: 3.0.7
 spring:
     groovy:
         template:


### PR DESCRIPTION
Updated to use the latest artifact, stop using deprecated GenericRestLookupController, and removed redundant `@RequestMapping` that seemed to be causing trouble for grails 3.0.3 and up.

Verified with grails 3.0.7 (latest).
