### PR TITLE
Add the (new, preferred) sonarqube plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,6 +3,10 @@ buildscript {
     dependencies { classpath 'com.bmuschko:gradle-nexus-plugin:2.3.1' }
 }
 
+plugins {
+    id "org.sonarqube" version "1.0"
+}
+
 subprojects {
 
     group = 'edu.wisc.my.restproxy'


### PR DESCRIPTION
This change does not mess with the regular build task, but adds a `gradle sonarqube` task that can be run to trigger analysis.
This is contingent on the builder either having Sonar running with default config locally, or supplying configuration via command line flags, or ~/.gradle/gradle.properties.

Gradle now recommends using this plugin from Sonarqube rather than their own ones.
https://discuss.gradle.org/t/important-changes-to-gradle-sonarqube-support/10252
