### PR TITLE
Release version 2.1.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 subprojects {
 
     group = 'edu.wisc.my.restproxy'
-    version = '2.1.0-SNAPSHOT'
+    version = '2.1.0'
 
     repositories {
         maven { url "https://oss.sonatype.org/content/repositories/snapshots/" }


### PR DESCRIPTION
There hasn't been any churn in 2.1.0-SNAPSHOT in a while and it appears stable, so let's harden the version.
