### PR TITLE
Removes trailing slash on blank resource path

### DIFF
--- a/rest-proxy-core/src/main/groovy/edu/wisc/my/restproxy/service/RestProxyServiceImpl.groovy
+++ b/rest-proxy-core/src/main/groovy/edu/wisc/my/restproxy/service/RestProxyServiceImpl.groovy
@@ -72,7 +72,7 @@ public class RestProxyServiceImpl implements RestProxyService {
       if(resourcePath.startsWith("/"+resourceKey)) {
         resourcePath = resourcePath.replaceFirst("/"+resourceKey, "");
       }
-      if(!StringUtils.endsWith(uri, "/") && !resourcePath.startsWith("/")) {
+      if(!StringUtils.endsWith(uri, "/") && StringUtils.isNotBlank(resourcePath) && !resourcePath.startsWith("/")) {
         uri.append("/");
       }
       uri.append(resourcePath);


### PR DESCRIPTION
Adds in a check.

Before - a `/` is appended between the uri and resource path if there wasn't one present.  Also, a `/` was appended if resource path was blank, thus adding a `/` to every url with no resource path.  This now checks to see if a resource path is even specified and if it isn't, no `/` is added.
