### PR TITLE
Issue 37 Trailing Slash with no additional path

### DIFF
--- a/rest-proxy-core/src/main/groovy/edu/wisc/my/restproxy/service/RestProxyServiceImpl.groovy
+++ b/rest-proxy-core/src/main/groovy/edu/wisc/my/restproxy/service/RestProxyServiceImpl.groovy
@@ -72,7 +72,7 @@ public class RestProxyServiceImpl implements RestProxyService {
       if(resourcePath.startsWith("/"+resourceKey)) {
         resourcePath = resourcePath.replaceFirst("/"+resourceKey, "");
       }
-      if(!StringUtils.endsWith(uri, "/") && !resourcePath.startsWith("/")) {
+      if(!StringUtils.endsWith(uri, "/") && StringUtils.isNotBlank(resourcePath) && !resourcePath.startsWith("/")) {
         uri.append("/");
       }
       uri.append(resourcePath);

--- a/rest-proxy-core/src/test/groovy/edu/wisc/my/restproxy/service/RestProxyServiceImplTest.groovy
+++ b/rest-proxy-core/src/test/groovy/edu/wisc/my/restproxy/service/RestProxyServiceImplTest.groovy
@@ -188,10 +188,10 @@ public class RestProxyServiceImplTest {
     request.setAttribute(HandlerMapping.PATH_WITHIN_HANDLER_MAPPING_ATTRIBUTE, "/withoutAdditionalHeaders");
     env.setProperty("withoutAdditionalHeaders.uri", "http://localhost/foo");
     ProxyRequestContext expected = new ProxyRequestContext("withoutAdditionalHeaders").setUri("http://localhost/foo");
-    ProxyRequestContext expected2 = new ProxyRequestContext("withoutAdditionalHeaders").setUri("http://localhost/foo/");
+    ProxyRequestContext notExpected = new ProxyRequestContext("withoutAdditionalHeaders").setUri("http://localhost/foo/");
     
     when(proxyDao.proxyRequest(expected)).thenReturn(result);
-    when(proxyDao.proxyRequest(expected2)).thenReturn(null);
+    when(proxyDao.proxyRequest(notExpected)).thenReturn(null);
     assertEquals(result, proxy.proxyRequest("withoutAdditionalHeaders", request));
   }
   

--- a/rest-proxy-core/src/test/groovy/edu/wisc/my/restproxy/service/RestProxyServiceImplTest.groovy
+++ b/rest-proxy-core/src/test/groovy/edu/wisc/my/restproxy/service/RestProxyServiceImplTest.groovy
@@ -173,6 +173,29 @@ public class RestProxyServiceImplTest {
     when(proxyDao.proxyRequest(expected)).thenReturn(result);
     assertEquals(result, proxy.proxyRequest("withAdditionalPath", request));
   }
+  
+  /**
+   * Experiment for {@link RestProxyServiceImpl#proxyRequest(String, HttpServletRequest)}, confirms
+   * expected behavior when the request path contains no additional fragments and the path
+   * within attribute is the same as the resource key
+   */
+  @Test
+  public void proxyRequest_withOutAdditionalPathResourceKeyIsSameAsResourcePath() {
+    final ResponseEntity<Object> result = new ResponseEntity<Object>(new Object(), HttpStatus.OK);
+
+    MockHttpServletRequest request = new MockHttpServletRequest();
+    request.setMethod("GET");
+    request.setAttribute(HandlerMapping.PATH_WITHIN_HANDLER_MAPPING_ATTRIBUTE, "/withoutAdditionalHeaders");
+    env.setProperty("withoutAdditionalHeaders.uri", "http://localhost/foo");
+    ProxyRequestContext expected = new ProxyRequestContext("withoutAdditionalHeaders").setUri("http://localhost/foo");
+    ProxyRequestContext expected2 = new ProxyRequestContext("withoutAdditionalHeaders").setUri("http://localhost/foo/");
+    
+    when(proxyDao.proxyRequest(expected)).thenReturn(result);
+    when(proxyDao.proxyRequest(expected2)).thenReturn(null);
+    assertEquals(result, proxy.proxyRequest("withoutAdditionalHeaders", request));
+  }
+  
+  
   /**
    * Experiment for {@link RestProxyServiceImpl#proxyRequest(String, HttpServletRequest)}
    * where the request has a 'application/json' body.


### PR DESCRIPTION
When your "key" - what's in the properties file is all that's on the path when rest proxy proxies your url, you will end up with a trailing slash. 

fixes https://github.com/UW-Madison-DoIT/rest-proxy/issues/37
