### PR TITLE
Issue41

### DIFF
--- a/rest-proxy-core/src/main/groovy/edu/wisc/my/restproxy/service/RestProxyServiceImpl.groovy
+++ b/rest-proxy-core/src/main/groovy/edu/wisc/my/restproxy/service/RestProxyServiceImpl.groovy
@@ -2,6 +2,8 @@ package edu.wisc.my.restproxy.service
 
 import groovy.transform.CompileStatic;
 
+import java.net.URLDecoder;
+
 import javax.servlet.http.HttpServletRequest;
 
 import org.apache.commons.lang3.StringUtils;
@@ -80,7 +82,7 @@ public class RestProxyServiceImpl implements RestProxyService {
 
     if(StringUtils.isNotBlank(request.getQueryString())) {
       uri.append("?");
-      uri.append(request.getQueryString());
+      uri.append(URLDecoder.decode(request.getQueryString()));
     }
 
     String username = env.getProperty(resourceKey + ".username");

--- a/rest-proxy-core/src/test/groovy/edu/wisc/my/restproxy/service/RestProxyServiceImplTest.groovy
+++ b/rest-proxy-core/src/test/groovy/edu/wisc/my/restproxy/service/RestProxyServiceImplTest.groovy
@@ -75,6 +75,30 @@ public class RestProxyServiceImplTest {
     when(proxyDao.proxyRequest(expected)).thenReturn(result);
     assertEquals(result, proxy.proxyRequest("control", request));
   }
+  
+  /**
+   * Test simulates a request with query parameters.  Testing against double encoding in the uri.
+   */
+  @Test
+  public void withQueryStringEncoding() {
+    final ResponseEntity<Object> result = new ResponseEntity<Object>(new Object(), HttpStatus.OK);
+
+    MockHttpServletRequest request = new MockHttpServletRequest();
+    request.setMethod("GET");
+    request.setAttribute(HandlerMapping.PATH_WITHIN_HANDLER_MAPPING_ATTRIBUTE, "/control/foo");
+    request.setQueryString("search=bar&name=bucky%20badger");
+    env.setProperty("control.uri", "http://destination");
+
+    //note the resourceKey ('control' in this context) is stripped from the uri
+    ProxyRequestContext expected = new ProxyRequestContext("control").setUri("http://destination/foo?search=bar&name=bucky badger");
+    ProxyRequestContext notExpected = new ProxyRequestContext("control").setUri("http://destination/foo?search=bar&name=bucky%20badger");
+
+    when(proxyDao.proxyRequest(expected)).thenReturn(result);
+    when(proxyDao.proxyRequest(notExpected)).thenReturn(null);
+    assertEquals(result, proxy.proxyRequest("control", request));
+  }
+
+
   /**
    * Test simulates a proxy request which fails with a http 400 error.
    * An error like this could be encountered if you were to post invalid data to a form.


### PR DESCRIPTION
Our `RestProxyDaoImpl` uses `restTemplate.exchange` which assumes a url which needs encoding.  We use `StringBuilder` to construct our url and append `request.getQueryParameters()` which returns an encoded string.  Solutions are to use a different builder such as `UriComponentsBuilder` or to decode the query parameters passed through to stop double encoding those.

Issue only discovered when passing query strings from the request that would result in encoding.

fixes https://github.com/UW-Madison-DoIT/rest-proxy/issues/41
