### PR TITLE
Upgrade dependencies and add CORS support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 subprojects {
 
     group = 'edu.wisc.my.restproxy'
-    version = '2.1.3-SNAPSHOT'
+    version = '2.2.0'
 
     repositories {
         maven { url "https://oss.sonatype.org/content/repositories/snapshots/" }

--- a/rest-proxy-core/build.gradle
+++ b/rest-proxy-core/build.gradle
@@ -9,14 +9,14 @@ sourceCompatibility = 1.7
 targetCompatibility = 1.7
 
 dependencies {
-    compile 'org.codehaus.groovy:groovy-all:2.4.4'
+    compile 'org.codehaus.groovy:groovy-all:2.4.6'
     compile 'org.apache.commons:commons-lang3:3.3.2'
     compile 'commons-codec:commons-codec:1.1'
     compile 'com.fasterxml.jackson.core:jackson-databind:2.2.0'
-    compile 'com.google.guava:guava:18.0'
-    compile 'org.springframework:spring-core:4.1.5.RELEASE'
-    compile 'org.springframework:spring-web:4.1.5.RELEASE'
-    compile 'org.springframework:spring-webmvc:4.1.5.RELEASE'
+    compile 'com.google.guava:guava:19.0'
+    compile 'org.springframework:spring-core:4.2.5.RELEASE'
+    compile 'org.springframework:spring-web:4.2.5.RELEASE'
+    compile 'org.springframework:spring-webmvc:4.2.5.RELEASE'
     compile 'org.slf4j:jcl-over-slf4j:1.7.5'
     compile 'org.slf4j:slf4j-api:1.7.5'
     runtime 'ch.qos.logback:logback-classic:1.0.12'
@@ -24,7 +24,7 @@ dependencies {
     runtime 'org.slf4j:log4j-over-slf4j:1.7.5'
     testCompile 'junit:junit:4.11'
     testCompile 'org.mockito:mockito-core:1.9.5'
-    testCompile 'org.springframework:spring-test:4.1.5.RELEASE'
+    testCompile 'org.springframework:spring-test:4.2.5.RELEASE'
     provided 'javax.servlet:javax.servlet-api:3.1.0'
 }
 

--- a/rest-proxy-core/src/main/groovy/edu/wisc/my/restproxy/web/ResourceProxyController.groovy
+++ b/rest-proxy-core/src/main/groovy/edu/wisc/my/restproxy/web/ResourceProxyController.groovy
@@ -10,6 +10,7 @@ import org.springframework.core.env.Environment;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseBody;
@@ -48,6 +49,7 @@ public class ResourceProxyController {
    * @param key
    * @return the body of the proxy response or null.
    */
+  @CrossOrigin
   @RequestMapping("/{key}/**")
   public @ResponseBody Object proxyResource(HttpServletRequest request,
       HttpServletResponse response,


### PR DESCRIPTION
So, I realized that the standalone rest proxy has two big usability issues right now:
1.  It doesn't support cross-origin requests.
2.  The spring boot "runnable jar" doesn't run (`gradle bootRun` still works).

This PR addresses 1, making it possible, e.g., to run uw-frame-static on one port and read todos from rest-proxy running on another port.
