### PR TITLE
Remove custom repositories and cache dependencies during Travis CI build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,10 @@
-language: java
+language: groovy
 jdk:
   - oraclejdk7
 sudo: false
-
+before_cache:
+  - rm -f $HOME/.gradle/caches/modules-2/modules-2.lock
+cache:
+  directories:
+    - $HOME/.gradle/caches/
+    - $HOME/.gradle/wrapper/

--- a/build.gradle
+++ b/build.gradle
@@ -10,13 +10,10 @@ plugins {
 subprojects {
 
     group = 'edu.wisc.my.restproxy'
-    version = '2.1.3'
+    version = '2.1.4'
 
     repositories {
-        maven { url "https://oss.sonatype.org/content/repositories/snapshots/" }
-        maven { url "https://code.doit.wisc.edu/maven/content/repositories/public-releases/" }
-        maven { url "https://code.doit.wisc.edu/maven/content/repositories/uw-releases/" }
-        maven { url "http://repo.maven.apache.org/maven2" }
+        mavenCentral()
     }
 
     apply plugin: 'groovy'


### PR DESCRIPTION
The Travis build seems to take a ridiculously long time (more than an hour) downloading dependencies, before aborting due to lack of output.
I don't understand why a jar or pomfile should take minutes to download, but caching might help.

See https://docs.travis-ci.com/user/languages/groovy#Caching
