### PR TITLE
Next release will be 3.0.0 , right?

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 subprojects {
 
     group = 'edu.wisc.my.restproxy'
-    version = '3.1.0'
+    version = '3.0.0'
 
     repositories {
         mavenCentral()


### PR DESCRIPTION
I'm confused about the state of versioning for `rest-proxy`. This PR as much expresses my confusion as it proposes a concrete change.

So, looking at releases, the most recent release seems to be `v2.1.4`. (EDIT: not actually the most recent release.)

![2 1 4 is latest release](https://cloud.githubusercontent.com/assets/952283/18559065/36068b80-7b3b-11e6-9d3e-be4a901b1501.png)

and I see no later tags.

![rest-proxy tags](https://cloud.githubusercontent.com/assets/952283/18559080/4c06fe60-7b3b-11e6-9187-ec7b4532cb28.png)

So, even given the breaking changes (path change) between latest and v2.1.4, the next release should be `3.0.0`, not `3.1.0`, right? (EDIT: Wrong.)
