### PR TITLE
Add Dependency Status badge.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 A Simple server side REST proxy service written in Groovy
 
 [![Build Status](https://travis-ci.org/UW-Madison-DoIT/rest-proxy.svg)](https://travis-ci.org/UW-Madison-DoIT/rest-proxy)
+[![Dependency Status](https://dependencyci.com/github/UW-Madison-DoIT/rest-proxy/badge)](https://dependencyci.com/github/UW-Madison-DoIT/rest-proxy)
 
 ### Purpose
 


### PR DESCRIPTION
The good news is that this adds the badge, the badge correctly links to the dependency-ci report, the dependency-ci service *does* run.

The bad news is that it detects zero dependencies, so the reassurance of this shiny badge is thin.