### PR TITLE
Add naive .codeclimate.yml

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,0 +1,7 @@
+---
+engines:
+  fixme:
+    enabled: true
+ratings:
+  paths: []
+exclude_paths: []


### PR DESCRIPTION
Enables code climate linting via [Atom plugin](https://docs.codeclimate.com/docs/code-climate-atom-package).

Naive analysis isn't actually all that useful currently -- will only catch "TODO" and the like in comments.

(This PR part of tying off loose ends from the 2017-is-a-new-year exploration of code quality tooling.)