### PR TITLE
Convert http responses regardless of content type.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,10 @@ Upgrading:
 
 The v3 series differs from the v2 series in prefixing proxy access with `/proxy/` (to create namespace for other functionality at paths other than `/proxy/`). This is a breaking change in that all usages of your `rest-proxy` instances will need to add a `/proxy/` to the URLs they are requesting across this upgrade.
 
+## 3.2.0
+
+Adds the ability to proxy any content type, rather than just application/json and a few other types.
+
 ## 3.1.0
 
 Adds a health check for each key.

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 subprojects {
 
     group = 'edu.wisc.my.restproxy'
-    version = '3.1.0'
+    version = '3.2.0'
 
     repositories {
         mavenCentral()

--- a/rest-proxy-boot/build.gradle
+++ b/rest-proxy-boot/build.gradle
@@ -10,7 +10,8 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath("org.springframework.boot:spring-boot-gradle-plugin:1.3.6.RELEASE")
+        classpath("org.springframework.boot:spring-boot-gradle-plugin:1.3.7.RELEASE")
+        classpath "io.spring.gradle:dependency-management-plugin:0.6.1.RELEASE"
     }
 }
 apply plugin: 'spring-boot'

--- a/rest-proxy-core/build.gradle
+++ b/rest-proxy-core/build.gradle
@@ -12,7 +12,6 @@ dependencies {
     compile 'org.codehaus.groovy:groovy-all:2.4.7'
     compile 'org.apache.commons:commons-lang3:3.4'
     compile 'commons-codec:commons-codec:1.10'
-    compile 'com.fasterxml.jackson.core:jackson-databind:2.8.0'
     compile 'com.google.guava:guava:19.0'
     compile 'org.springframework:spring-core:4.3.1.RELEASE'
     compile 'org.springframework:spring-web:4.3.1.RELEASE'

--- a/rest-proxy-core/src/main/groovy/edu/wisc/my/restproxy/dao/AgnosticHttpMessageConverter.groovy
+++ b/rest-proxy-core/src/main/groovy/edu/wisc/my/restproxy/dao/AgnosticHttpMessageConverter.groovy
@@ -1,0 +1,53 @@
+package edu.wisc.my.restproxy.dao
+
+import com.google.common.io.ByteStreams
+import org.apache.commons.lang3.NotImplementedException
+import org.springframework.http.HttpInputMessage
+import org.springframework.http.HttpOutputMessage
+import org.springframework.http.MediaType
+import org.springframework.http.converter.AbstractHttpMessageConverter
+import org.springframework.web.servlet.mvc.method.annotation.StreamingResponseBody
+
+/**
+ * This converter supports reading all content types into an {@link Object} by copying the byte stream.
+ * It does not write any requests.
+ *
+ * @author Craig Knuth
+ */
+class AgnosticHttpMessageConverter extends AbstractHttpMessageConverter<Object> {
+
+    private static final Class<Object> SUPPORTED_CLASS = Object.class
+
+    AgnosticHttpMessageConverter() {
+        super(MediaType.ALL)
+    }
+
+    @Override
+    protected boolean supports(Class<?> clazz) {
+        return SUPPORTED_CLASS == clazz
+    }
+
+    @Override
+    boolean canWrite(Class<?> clazz, MediaType mediaType) {
+        return false
+    }
+
+    @Override
+    protected Object readInternal(Class<? extends Object> clazz, HttpInputMessage inputMessage) {
+        // input stream will close by the time writeTo() is called, so we must extract the data here
+        InputStream input = inputMessage.getBody()
+        byte[] data = ByteStreams.toByteArray(input)
+        return new StreamingResponseBody() {
+            @Override
+            void writeTo(OutputStream output) throws IOException {
+                output.write(data)
+            }
+        }
+    }
+
+    @Override
+    protected void writeInternal(Object object, HttpOutputMessage outputMessage) {
+        throw new NotImplementedException("AgnosticHttpMessageConverter can only read http messages")
+    }
+
+}

--- a/rest-proxy-core/src/main/groovy/edu/wisc/my/restproxy/dao/RestProxyDaoImpl.groovy
+++ b/rest-proxy-core/src/main/groovy/edu/wisc/my/restproxy/dao/RestProxyDaoImpl.groovy
@@ -2,7 +2,8 @@ package edu.wisc.my.restproxy.dao
 
 import edu.wisc.my.restproxy.JWTUtils
 import edu.wisc.my.restproxy.model.ProxyAuthMethod
-import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatus
+import org.springframework.http.converter.HttpMessageConverter;
 
 import java.util.Map.Entry;
 
@@ -42,6 +43,7 @@ public class RestProxyDaoImpl implements RestProxyDao, InitializingBean {
   @Override
   public void afterPropertiesSet() throws Exception {
     this.restTemplate.setErrorHandler(new RestProxyResponseErrorHandler());
+    this.restTemplate.setMessageConverters(Arrays.asList(new AgnosticHttpMessageConverter()))
   };
 
   private static final Logger logger = LoggerFactory.getLogger(RestProxyDaoImpl.class);

--- a/rest-proxy-core/src/test/groovy/edu/wisc/my/restproxy/dao/AgnosticHttpMessageConverterTest.groovy
+++ b/rest-proxy-core/src/test/groovy/edu/wisc/my/restproxy/dao/AgnosticHttpMessageConverterTest.groovy
@@ -1,0 +1,60 @@
+package edu.wisc.my.restproxy.dao
+
+import org.apache.commons.lang3.NotImplementedException
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mockito
+import org.mockito.runners.MockitoJUnitRunner
+import org.springframework.http.HttpOutputMessage
+import org.springframework.http.MediaType
+import org.springframework.mock.http.MockHttpInputMessage
+import org.springframework.mock.http.MockHttpOutputMessage
+import org.springframework.web.servlet.mvc.method.annotation.StreamingResponseBody
+
+import static org.mockito.Matchers.eq
+import static org.mockito.Mockito.mock
+
+/**
+ * Tests the functionality of {@link AgnosticHttpMessageConverter}
+ *
+ * @author Craig Knuth
+ */
+@RunWith(MockitoJUnitRunner.class)
+class AgnosticHttpMessageConverterTest {
+
+    AgnosticHttpMessageConverter converter = new AgnosticHttpMessageConverter()
+
+    @Test
+    void agnosticConverter_canReadAllContentTypes() {
+        assert converter.canRead(Object.class, MediaType.ALL)
+    }
+
+    @Test
+    void agnosticConverter_cannotWriteAnyContentType() {
+        assert !converter.canWrite(Object.class, MediaType.APPLICATION_JSON)
+        assert !converter.canWrite(Object.class, MediaType.TEXT_HTML)
+        assert !converter.canWrite(Object.class, MediaType.TEXT_PLAIN)
+        assert !converter.canWrite(Object.class, MediaType.TEXT_XML)
+        assert !converter.canWrite(Object.class, MediaType.ALL)
+    }
+
+    @Test
+    void agnosticConverter_readsIntoStreamingResponseBody() {
+        byte[] data = "just a test".getBytes()
+        MockHttpInputMessage input = new MockHttpInputMessage(data)
+        Object result = converter.read(Object.class, input)
+        assert result instanceof StreamingResponseBody
+
+        OutputStream output = mock(OutputStream)
+        ((StreamingResponseBody)result).writeTo(output)
+        Mockito.verify(output).write(eq(data))
+    }
+
+    @Test(expected = NotImplementedException)
+    void agnosticConverter_doesNotWrite() {
+        Object o = new Object()
+        HttpOutputMessage out = new MockHttpOutputMessage()
+        converter.writeInternal(o, out)
+    }
+
+}


### PR DESCRIPTION
In the STAR rewrite, we ran into a problem proxying a csv report from our backend service to the user. To solve this, I added an agnostic http message converter that will proxy any request regardless of content type.

This converter also eliminates the need for Jackson, so I removed that.