### PR TITLE
Include old json converters

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 subprojects {
 
     group = 'edu.wisc.my.restproxy'
-    version = '3.2.0'
+    version = '3.2.1'
 
     repositories {
         mavenCentral()

--- a/rest-proxy-core/build.gradle
+++ b/rest-proxy-core/build.gradle
@@ -13,6 +13,7 @@ dependencies {
     compile 'org.apache.commons:commons-lang3:3.4'
     compile 'commons-codec:commons-codec:1.10'
     compile 'com.google.guava:guava:19.0'
+    compile 'com.fasterxml.jackson.core:jackson-databind:2.8.0'
     compile 'org.springframework:spring-core:4.3.1.RELEASE'
     compile 'org.springframework:spring-web:4.3.1.RELEASE'
     compile 'org.springframework:spring-webmvc:4.3.1.RELEASE'

--- a/rest-proxy-core/src/main/groovy/edu/wisc/my/restproxy/dao/RestProxyDaoImpl.groovy
+++ b/rest-proxy-core/src/main/groovy/edu/wisc/my/restproxy/dao/RestProxyDaoImpl.groovy
@@ -43,7 +43,9 @@ public class RestProxyDaoImpl implements RestProxyDao, InitializingBean {
   @Override
   public void afterPropertiesSet() throws Exception {
     this.restTemplate.setErrorHandler(new RestProxyResponseErrorHandler());
-    this.restTemplate.setMessageConverters(Arrays.asList(new AgnosticHttpMessageConverter()))
+    List<HttpMessageConverter> converters = restTemplate.getMessageConverters()
+    converters.add(new AgnosticHttpMessageConverter())
+    this.restTemplate.setMessageConverters(converters)
   };
 
   private static final Logger logger = LoggerFactory.getLogger(RestProxyDaoImpl.class);


### PR DESCRIPTION
It appears I was a bit overzealous in removing the old converters from Jackson. On some requests the RestTemplate infers the class, rather than simply using Object.class.

I plan to do a little more looking into this early next week to establish what exactly is needed in the converters.